### PR TITLE
Server.tick() Should return the server instance itself.

### DIFF
--- a/src/screepsServer.ts
+++ b/src/screepsServer.ts
@@ -134,6 +134,7 @@ export class ScreepsServer extends EventEmitter {
         await driver.updateAccessibleRoomsList();
         await driver.notifyRoomsDone(gameTime);
         await (driver.config as any).mainLoopCustomStage();
+        return this;
     }
 
     /*


### PR DESCRIPTION
Just for consistency, all of the other server methods (except start child process) return the original server instance, I suppose for chaining.

Might as well make tick do the same.