### PR TITLE
NPM Publish options for Typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,16 +5,16 @@
   "license": "MIT",
   "repository": "https://github.com/screepers/screeps-server-mockup",
   "dependencies": {
+    "@types/fs-extra-promise": "^1.0.8",
+    "@types/lodash": "^4.14.149",
+    "@types/screeps": "^3.0.0",
     "fs-extra-promise": "^1.0.1",
     "lodash": "^4.17.15",
     "screeps": "^4.0.5"
   },
   "devDependencies": {
-    "@types/fs-extra-promise": "^1.0.8",
-    "@types/lodash": "^4.14.149",
     "@types/mocha": "^7.0.1",
     "@types/node": "10.17.16",
-    "@types/screeps": "^3.0.0",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "screeps-server-mockup",
-  "main": "./src/main.js",
+  "main": "./dist/src/main.js",
+  "types": "./dist/src/main.d.ts",
   "license": "MIT",
   "repository": "https://github.com/screepers/screeps-server-mockup",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "build": "tsc",
     "coverage": "tsc && nyc mocha dist/test --ui tdd --exit",
     "lint": "eslint src examples test",
+    "prepare": "yarn run build",
+    "prepublishOnly": "yarn run test",
     "test": "tsc && mocha dist/test --ui tdd --exit"
   },
   "version": "1.5.0"

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,4 +2,4 @@ import {ScreepsServer} from './screepsServer';
 const stdHooks = require('../utils/stdhooks');
 import {Matrix as TerrainMatrix} from './terrainMatrix';
 
-module.exports = { ScreepsServer, stdHooks, TerrainMatrix };
+export { ScreepsServer, stdHooks, TerrainMatrix };

--- a/src/user.ts
+++ b/src/user.ts
@@ -2,7 +2,7 @@
 
 import { EventEmitter } from 'events';
 import * as _ from 'lodash';
-import { ScreepsServer } from 'screepsServer';
+import { ScreepsServer } from './screepsServer';
 
 type Notification = { message: string, type: string, date: number, count: number, _id: string }
 

--- a/src/world.ts
+++ b/src/world.ts
@@ -1,9 +1,9 @@
 import * as _ from 'lodash';
 import * as util from 'util';
 import * as zlib from 'zlib';
-import {Matrix as TerrainMatrix} from './terrainMatrix';
+import { Matrix as TerrainMatrix } from './terrainMatrix';
 import User from './user';
-import {ScreepsServer} from 'screepsServer';
+import { ScreepsServer } from './screepsServer';
 
 interface AddBotOptions {
     username: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "Node",
     "outDir": "dist",
     "baseUrl": "src/",
+    "allowJs": true,
     "declaration": true,
     "strict": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
Added some fields to `package.json` to prepare the package to publish the typescript version.

- Pointed `main` and `types` to the compiled `.js` and `.d.ts` typings files.
- `@types` packages of direct dependencies moved to direct dependencies themselves so consumers will be fully typed
- Fixed export in main.ts
- Added `prepare` and `prepublishOnly` scripts to build and test the compiled `.js` before `npm publish`