### PR TITLE
Final prep for publishing Typescript package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Typescript Support (TODO: Add link to final pull request typescript -> master)
+
 ## [1.5.1] - 2020-04-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "yarn run build && mocha dist/test --ui tdd --exit"
   },
   "files": [
+    "assets",
     "dist/src",
     "dist/utils"
   ],

--- a/package.json
+++ b/package.json
@@ -1,19 +1,22 @@
 {
   "name": "screeps-server-mockup",
-  "main": "./dist/src/main.js",
-  "types": "./dist/src/main.d.ts",
   "license": "MIT",
   "repository": "https://github.com/screepers/screeps-server-mockup",
   "version": "1.5.1",
-  "main": "./src/main.js",
+  "main": "dist/src/main.js",
+  "types": "dist/src/main.d.ts",
   "scripts": {
     "build": "tsc",
-    "coverage": "tsc && nyc mocha dist/test --ui tdd --exit",
+    "coverage": "yarn run build && nyc mocha dist/test --ui tdd --exit",
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\" \"utils/**/*.ts\"",
     "prepare": "yarn run build",
     "prepublishOnly": "yarn test && yarn run lint",
-    "test": "tsc && mocha dist/test --ui tdd --exit"
+    "test": "yarn run build && mocha dist/test --ui tdd --exit"
   },
+  "files": [
+    "dist/src",
+    "dist/utils"
+  ],
   "dependencies": {
     "@types/fs-extra-promise": "^1.0.8",
     "@types/lodash": "^4.14.149",

--- a/src/screepsServer.ts
+++ b/src/screepsServer.ts
@@ -70,7 +70,7 @@ export default class ScreepsServer extends EventEmitter {
     }
 
     /*
-        Set the current server options. Missing values
+        Set the current server options. Missing values will use defaults
     */
     setOpts(opts: ScreepServerOptions) {
         this.opts = this.computeDefaultOpts(opts);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,16 +2,15 @@
   "compilerOptions": {
     "module": "CommonJS",
     "lib": [
-      "esnext"
+      "ES2018"
     ],
-    "target": "esnext",
+    "target": "ES2018",
     "moduleResolution": "Node",
     "outDir": "dist",
     "baseUrl": "src/",
     "allowJs": true,
     "declaration": true,
     "strict": true,
-    "experimentalDecorators": true,
     "noImplicitReturns": true,
     "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false


### PR DESCRIPTION
Changed Typescript compilation target to es2018 to match recommended targets for Node10
See: https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping

Limited npm published files to the dist directory (excluding tests) so that we only publish useful artifacts.

Updated Changelog

---

This is the last step required publish this package as a TypeScript project. Once this is merged we can merge the TypeScript Branch into the main Master branch and do a release.

I have confirmed that the final bundle includes the necessary files. You can test it in your own project by including the beta version of the project I uploaded myself to npm for testing purposes.

`yarn add -D @brisberg/screeps-server-mockup@1.5.1`

I will delete this package when we are done here.

---

I would very much like to get this release out so we can avoid maintaining two branches in limbo.