### PR TITLE
[Critical] Fixed addBot to activate the room the Bot is assigned

### DIFF
--- a/src/screepsServer.js
+++ b/src/screepsServer.js
@@ -44,6 +44,7 @@ class ScreepsServer extends EventEmitter {
         this.opts = { ...{
             path:   path.resolve('server'),
             logdir: path.resolve('server', 'logs'),
+            modfile: path.resolve('server', MOD_FILE),
             port:   21025,
         }, ...opts };
         // Define environment parameters

--- a/src/world.js
+++ b/src/world.js
@@ -157,6 +157,21 @@ class World {
     }
 
     /**
+        Generate a random badge for a user.
+        Taken from https://github.com/screeps/backend-local/blob/master/lib/cli/bots.js#L37.
+     */
+    genRandomBadge() {
+        var badge = {};
+        badge.type = Math.floor(Math.random()*24)+1;
+        badge.color1 = '#'+Math.floor(Math.random()*0xffffff).toString(16);
+        badge.color2 = '#'+Math.floor(Math.random()*0xffffff).toString(16);
+        badge.color3 = '#'+Math.floor(Math.random()*0xffffff).toString(16);
+        badge.flip = Math.random() > 0.5;
+        badge.param = Math.floor(Math.random()*200) - 100;
+        return badge;
+    }
+
+    /**
         Add a new user to the world
     */
     async addBot({ username, room, x, y, gcl = 1, cpu = 100, cpuAvailable = 10000, active = 10000, spawnName = 'Spawn1', modules = {} }) {
@@ -167,9 +182,10 @@ class World {
             throw new Error(`cannot add user in ${room}: room does not have any controller`);
         }
         // Insert user and update data
-        const user = await db.users.insert({ username, cpu, cpuAvailable, gcl, active });
+        const user = await db.users.insert({ username, cpu, cpuAvailable, gcl, active, badge: this.genRandomBadge()});
         await Promise.all([
             env.set(env.keys.MEMORY + user._id, '{}'),
+            env.sadd(env.keys.ACTIVE_ROOMS, room),
             db.rooms.update({ _id: room }, { $set: { active: true } }),
             db['users.code'].insert({ user: user._id, branch: 'default', modules, activeWorld: true }),
             db['rooms.objects'].update({ room, type: 'controller' }, { $set: { user: user._id, level: 1, progress: 0, downgradeTime: null, safeMode: 20000 } }),


### PR DESCRIPTION
Fixes a critical, current issue with the latest Screeps implementation.

Screeps now requires rooms to be specifically added to an environment variable before they will be run and process by the engine. 

See: https://github.com/screeps/backend-local/blob/master/lib/cli/bots.js#L123

---

Additionally, users need to have a user badge in the database or the private server can stop working. It was causing some instability recently. We should bring the addBot code up to spec with screeps/backend.

--- 

Server options was not initializing `modpath`. I think that was my bad since some time ago. My local server was complaining about not finding the mods file.